### PR TITLE
(chore): rease workflow

### DIFF
--- a/.github/workflows/release-node-package.yml
+++ b/.github/workflows/release-node-package.yml
@@ -1,0 +1,22 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22.13.0
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
usage op basis van https://github.com/yardinternet/reactive-search/blob/main/.github/workflows/release-package.yml
(bij de toolkit package kan de test job worden weggelaten)
```yml

name: Node.js Package

on:
  release:
    types: [created]

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: actions/setup-node@v3
        with:
          node-version: 22.13.0
      - run: npm ci
      - run: npm test

  publish-gpr:
    needs: build
    uses: yardinternet/workflows/.github/workflows/release-node-package.yml@main
    secrets: inherit

```
