### PR TITLE
(feat): configurable php-version input variable

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,7 +1,13 @@
 name: Create Badges
 
 on:
-  - workflow_call
+  workflow_call:
+    inputs:
+      php-version:
+        description: 'The PHP version used to run the workflow.'
+        required: false
+        type: string
+        default: '8.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +29,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@2.31.1
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs.php-version }}
           extensions:  simplexml, dom, xml, xdebug, intl
           tools: composer:v2
         env:

--- a/.github/workflows/format-php.yml
+++ b/.github/workflows/format-php.yml
@@ -1,7 +1,18 @@
 name: PHP CS Fixer
 
 on:
-  - workflow_call
+  workflow_call:
+    inputs:
+      php-version:
+        description: 'The PHP version used to run the workflow.'
+        required: false
+        type: string
+        default: '8.1'
+      php-cs-fixer-ignore-env:
+        description: 'Set to true to ignore PHP CS Fixer PHP version requirement'
+        required: false
+        type: string
+        default: 'false'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,7 +31,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs.php-version }}
           tools: composer:v2
           coverage: none
         env:
@@ -40,6 +51,8 @@ jobs:
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: ${{ inputs.php-cs-fixer-ignore-env }}
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,7 +1,13 @@
 name: PHPStan
 
 on:
-  - workflow_call
+  workflow_call:
+    inputs:
+      php-version:
+        description: 'The PHP version used to run the workflow.'
+        required: false
+        type: string
+        default: '8.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,7 +26,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.1'
+                  php-version: ${{ inputs.php-version }}
                   tools: composer:v2
                   coverage: none
               env:


### PR DESCRIPTION
PHP CS Fixer ondersteund nog geen php 8.4.

Vanuit zorgsites ([PR157](https://github.com/yardinternet/zorgsites/pull/157/files)):
![Scherm­afbeelding 2025-05-12 om 14 30 16](https://github.com/user-attachments/assets/177cf12b-67c0-4df9-9fe4-8c8d68cd8c69)

Met als resultaat:
![Scherm­afbeelding 2025-05-12 om 14 30 49](https://github.com/user-attachments/assets/00a57129-4647-48d5-8f6b-df1e21f2b407)

