### PR TITLE
Composer won't install due to shivammathur/setup-php issue

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.31.1
+        uses: shivammathur/setup-php@v2.35.1
         with:
           php-version: ${{ inputs.php-version }}
           extensions:  simplexml, dom, xml, xdebug, intl
           tools: composer:v2
+          github-token: ${{ secrets.YARD_BOT_PAT }}
         env:
-          COMPOSER_TOKEN: ${{ secrets.YARD_BOT_PAT }}
           COMPOSER_AUTH_JSON: |
             {
               "http-basic": {

--- a/.github/workflows/format-php.yml
+++ b/.github/workflows/format-php.yml
@@ -29,13 +29,13 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.35.1
         with:
           php-version: ${{ inputs.php-version }}
           tools: composer:v2
           coverage: none
+          github-token: ${{ secrets.YARD_BOT_PAT }}
         env:
-          COMPOSER_TOKEN: ${{ secrets.YARD_BOT_PAT }}
           COMPOSER_AUTH_JSON: |
             {
               "http-basic": {

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -24,13 +24,13 @@ jobs:
                 fetch-depth: 0
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@v2.35.1
               with:
                   php-version: ${{ inputs.php-version }}
                   tools: composer:v2
                   coverage: none
+                  github-token: ${{ secrets.YARD_BOT_PAT }}
               env:
-                  COMPOSER_TOKEN: ${{ secrets.YARD_BOT_PAT }}
                   COMPOSER_AUTH_JSON: |
                     {
                       "http-basic": {

--- a/.github/workflows/run-laravel-testbench-tests.yml
+++ b/.github/workflows/run-laravel-testbench-tests.yml
@@ -45,14 +45,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.35.1
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, xdebug
           coverage: xdebug
           tools: composer:v2
+          github-token: ${{ secrets.YARD_BOT_PAT }}
         env:
-          COMPOSER_TOKEN: ${{ secrets.YARD_BOT_PAT }}
           COMPOSER_AUTH_JSON: |
             {
               "http-basic": {

--- a/.github/workflows/run-pest-tests.yml
+++ b/.github/workflows/run-pest-tests.yml
@@ -35,14 +35,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.35.1
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, xdebug
           coverage: xdebug
           tools: composer:v2
+          github-token: ${{ secrets.YARD_BOT_PAT }}
         env:
-          COMPOSER_TOKEN: ${{ secrets.YARD_BOT_PAT }}
           COMPOSER_AUTH_JSON: |
             {
               "http-basic": {


### PR DESCRIPTION
shivammathur/setup-php removed `COMPOSER_TOKEN` support. Patched it after backlash. 
But is still broken. 

Remove `COMPOSER_TOKEN`  add `github-token` and lock to version `v2.35.1` as this should fix the problem.

https://github.com/shivammathur/setup-php/issues/979

When issue above is patched the version should be reverted to `v2`