### PR TITLE
fix: add package-lock check for pnpm projects

### DIFF
--- a/.github/workflows/npm-lock-diff.yml
+++ b/.github/workflows/npm-lock-diff.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0 # Required to make it possible to compare with PR base branch
       - name: NPM Lockfile Changes
+        if: hashFiles('package-lock.json') != ''
         uses: rvanvelzen/npm-lockfile-changes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Deze action gaat kapot als er geen `package-lock.json` in het project staat, zie bijv dit pnpm project https://github.com/yardinternet/terneuzen/actions/runs/18241864517/job/51944791733?pr=7. Dit fixt het (met gebruik van [hashFiles](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#hashfiles))

`pnpm-lock.yaml` files zijn al readable voor git diffs, dus deze Github Action is niet nodig voor pnpm projecten. 