### PR TITLE
fix: dependabot comment depreciation

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,7 +17,7 @@ jobs:
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         steps:
             - name: Enable auto-merge for Dependabot PRs
-              run: gh pr comment "$PR_URL" --body "@dependabot merge"
+              run: gh pr review "$PR_URL" --approve && gh pr merge "$PR_URL" --admin --rebase
               env:
                   PR_URL: ${{github.event.pull_request.html_url}}
                   GH_TOKEN: ${{secrets.YARD_BOT_PAT}}


### PR DESCRIPTION
This pull request updates the workflow for automerging Dependabot pull requests. Instead of just commenting to trigger a merge, the workflow now explicitly approves and merges Dependabot PRs using GitHub CLI commands.

**Workflow automation improvements:**

* The `dependabot-automerge.yml` workflow now approves Dependabot pull requests and merges them directly using `gh pr review --approve` and `gh pr merge --admin --rebase`, replacing the previous approach of commenting "@dependabot merge".

This is needed because GitHub deprecated the `@dependabot merge` command; despite negative feedback from the community https://github.com/orgs/community/discussions/176097
https://github.blog/changelog/2026-01-27-changes-to-github-dependabot-pull-request-comment-commands/

Tested in a few repos, e.g. https://github.com/yardinternet/nutshell/pull/32
<img width="950" height="155" alt="image" src="https://github.com/user-attachments/assets/d28c628e-7936-4ea2-8126-f0ccbaac6c83" />
