### PR TITLE
feat: add zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+        - ./github.**.yml
+        - ./**/action.yml
+  pull_request:
+    paths:
+        - ./github.**.yml
+        - ./**/action.yml
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: ["main"]
     paths:
-        - ./github.**.yml
+        - ./.github/workflows/*.yml
         - ./**/action.yml
   pull_request:
     paths:
-        - ./github.**.yml
+        - ./.github/workflows/*.yml
         - ./**/action.yml
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,12 +4,20 @@ on:
   push:
     branches: ["main"]
     paths:
-        - ./.github/workflows/*.yml
-        - ./**/action.yml
+      - ./.github/workflows/**.yml
+      - ./**/action.yml
   pull_request:
     paths:
-        - ./.github/workflows/*.yml
-        - ./**/action.yml
+      - ./.github/workflows/**.yml
+      - ./**/action.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,26 +3,18 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 on:
   push:
     branches: ["main"]
-    paths:
-      - ./.github/workflows/**.yml
-      - ./**/action.yml
   pull_request:
-    paths:
-      - ./.github/workflows/**.yml
-      - ./**/action.yml
+    branches: ["**"]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+      contents: read # only needed for private or internal repos
+      actions: read # only needed for private or internal repos
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to enable automated security analysis using Zizmor. The workflow is triggered on pushes to the `main` branch and on all pull requests, and it sets up the necessary permissions and steps to run the Zizmor action.

**Security automation:**
* Added `.github/workflows/zizmor.yml` to configure a GitHub Actions workflow that runs Zizmor security analysis on pushes to `main` and all pull requests. The workflow checks out the repository and executes the Zizmor action with appropriate permissions for security event reporting.